### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,6 @@
 include README.md
 include MANIFEST.in
+include LICENSE.txt
+include requirements.txt
+
+recursive-include examples *.py


### PR DESCRIPTION
Include the license file.  The MIT license requires all copies of the code include the license.  Include the requirements.  Include the example.